### PR TITLE
Add Status Page link to footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -50,14 +50,31 @@ export function Footer() {
   Thank you for respecting the effort that went into Tinynews.
 */}
 
-      <div>
-        {siteConfig.footer.copyrightText}
-        {siteConfig.footer && (
-          <>
-            &middot; Built with <a href="https://github.com/stefangotikj/tinynews-blog" target="_blank" rel="noopener noreferrer" className="underline hover:text-accent">Tinynews</a>
-          </>
-        )}
-      </div>
+<div>
+  {siteConfig.footer.copyrightText}
+  {siteConfig.footer && (
+    <>
+      {" · "}Built with{" "}
+      <a
+        href="https://github.com/stefangotikj/tinynews-blog"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline hover:text-accent"
+      >
+        Tinynews
+      </a>
+      {" · "}
+      <a
+        href="https://status.tinynews.site"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline hover:text-accent"
+      >
+        Status Page
+      </a>
+    </>
+  )}
+</div>
     </footer>
   );
 }


### PR DESCRIPTION
The footer now includes a link to the Tinynews Status Page alongside the existing Tinynews link, improving user access to service status information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Status Page" link to the footer section, displayed alongside the existing "Built with Tinynews" link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->