### PR TITLE
Comment out YouTube link in social config Update site config to comment out YouTube and activate Instagram link

### DIFF
--- a/src/site.config.ts
+++ b/src/site.config.ts
@@ -121,12 +121,12 @@ export const siteConfig: SiteConfig = {
   // ===== SOCIAL MEDIA LINKS =====
   // Remove or comment out any platforms you don't use
   social: {
-   // twitter: "https://twitter.com/yourusername",
-    github: "https://github.com/stefangotikj/tinynews-blog",
-   // linkedin: "https://linkedin.com/in/yourusername",
-    youtube: "https://youtube.com/@yourchannel",
-    instagram: "https://instagram.com/tinynews.site",
-    // facebook: "https://facebook.com/yourpage",
+  //twitter: "https://twitter.com/yourusername",
+  github: "https://github.com/stefangotikj/tinynews-blog",
+  //linkedin: "https://linkedin.com/in/yourusername",
+  //youtube: "https://youtube.com/@yourchannel",
+  instagram: "https://instagram.com/tinynews.site",
+  //facebook: "https://facebook.com/yourpage",
   },
   
   // ===== FOOTER CONFIGURATION =====


### PR DESCRIPTION
The YouTube link in the social media section of site.config.ts was commented out, likely to hide it from the site or disable its display. No other social links were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated social media links by disabling the YouTube link and ensuring the Instagram link remains active. Other social links are unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->